### PR TITLE
fix for checking the exit code

### DIFF
--- a/src/pre-commit
+++ b/src/pre-commit
@@ -30,7 +30,7 @@ if [ "$FILES" != "" ]
 then
     echo "Running Code Sniffer. Code standard PSR2."
     ./vendor/bin/phpcs --standard=PSR2 --encoding=utf-8 -n -p $FILES
-    if [ $? ne 0 ]
+    if [ $? != 0 ]
     then
         echo "Fix the error before commit!"
         echo "Run"


### PR DESCRIPTION
It could be `-ne` but not `ne`. I used `!=` for consistency with the previous code block