### PR TITLE
Change phpcs command. Check for staged but then modified files

### DIFF
--- a/src/pre-commit
+++ b/src/pre-commit
@@ -1,7 +1,8 @@
 #!/bin/sh
 
-PROJECT=`php -r "echo dirname(dirname(dirname(realpath('$0'))));"`
-STAGED_FILES_CMD=`git diff --cached --name-only --diff-filter=ACMR HEAD | grep \\\\.php`
+PROJECT=$(php -r "echo dirname(dirname(dirname(realpath('$0'))));")
+STAGED_FILES_CMD=$(git diff --cached --name-only --diff-filter=ACMR HEAD | grep \\.php)
+UNSTAGED_FILES_CMD=$(git diff --name-only --diff-filter=ACMR | grep \\.php)
 
 # Determine if a file list is passed
 if [ "$#" -eq 1 ]
@@ -12,7 +13,19 @@ then
     SFILES="$1"
     IFS=$oIFS
 fi
+
 SFILES=${SFILES:-$STAGED_FILES_CMD}
+
+STAGED_BUT_MODIFIED_FILES=$(php -r "\$sfiles=(explode(\"\\n\", '$SFILES'));\$usfiles=(explode(\"\\n\", '$UNSTAGED_FILES_CMD'));echo implode(\"\\n\",array_intersect(\$usfiles,\$sfiles));")
+
+if [ -z "$STAGED_BUT_MODIFIED_FILES" ]; then
+    echo "OK"
+else
+    echo "Files staged but then modified:\n"
+    echo "${STAGED_BUT_MODIFIED_FILES}"
+    exit 1
+fi
+
 
 echo "Checking PHP Lint..."
 for FILE in $SFILES
@@ -28,8 +41,8 @@ done
 
 if [ "$FILES" != "" ]
 then
-    echo "Running Code Sniffer. Code standard PSR2."
-    ./vendor/bin/phpcs --standard=PSR2 --encoding=utf-8 -n -p $FILES
+    echo "Running Code Sniffer."
+    ./vendor/bin/phpcs -n -p $FILES
     if [ $? != 0 ]
     then
         echo "Fix the error before commit!"


### PR DESCRIPTION
I made several changes to your script.

1. use $() instead of `
2. do not hardcode PSR standard or charset. These should be configured in the phpcs.xml(.dist) in the project root folder
3. imagine a case where you make some changes to file, do `git add file.php` This has an error in PHPCS, but you fix the file. But dont add it. At this point the staged file has a PHPCS error, but the actual file on system does NOT. What I do here is check if there are any unstaged changes to files that are already staged, and if yes, then error and exit.

An alternative (and better) approach to 3. would be to fetch from git the actual staged file contents and run phpcs on it instead of the live version in folder. But I am not sure how to achieve that, so I made this workaround which prevents pushing of phpcs buggy code